### PR TITLE
Fix for f5_snatpool type/provider

### DIFF
--- a/lib/puppet/type/f5_snatpool.rb
+++ b/lib/puppet/type/f5_snatpool.rb
@@ -1,3 +1,4 @@
+require 'puppet/property/list'
 Puppet::Type.newtype(:f5_snatpool) do
   @doc = "Manage F5 snatpool."
 
@@ -18,12 +19,20 @@ Puppet::Type.newtype(:f5_snatpool) do
   newparam(:name, :namevar=>true) do
     desc "The snatpool name."
   end
+  
+  newparam(:membership) do
+    defaultto :inclusive
+  end
 
-  newproperty(:member, :array_matching => :all) do
+  newproperty(:member, :parent => Puppet::Property::List) do
     desc "The snatpool member."
 
-    #munge do |value|
-    #  Array(value)
-    #end
+    munge do |value|
+      if value =~ /^([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])\.([01]?\d\d?|2[0-4]\d|25[0-5])$/ then
+        return value
+      else
+        raise "A valid IP address is required for the member property."
+      end
+    end
   end
 end


### PR DESCRIPTION
The f5_snatpool type and provider were able to display the current
state of a snatpool, and were even able to make changes, but still
displayed a message that they were changing resources even when
they weren't.

This change allows for comparison of structured data by reducing it
to a string and comparing it that way.  It's not the most ideal way
to do it, but it's the method we currently have at our disposal.
