### PR TITLE
Improve F5 support for 64 bit & network:port

### DIFF
--- a/lib/puppet/provider/f5.rb
+++ b/lib/puppet/provider/f5.rb
@@ -4,6 +4,26 @@ class Puppet::Provider::F5 < Puppet::Provider
 
   attr_accessor :device
 
+  # convert 64bit Integer to F5 representation as {:high => 32bit, :low => 32bit}
+  def to_32h(value)
+    high = (value.to_i & 0xFFFFFFFF00000000) >> 32
+    low  = value.to_i & 0xFFFFFFFF
+    {:high => high, :low => low}
+  end
+
+  # convert F5 representation of 64 bit to string (since Puppet compares string rather than int)
+  def to_64s(value)
+    ((value.high.to_i << 32) + value.low.to_i).to_s
+  end
+
+  def network_address(value)
+    value.split(':')[0]
+  end
+
+  def network_port(value)
+    (value.split(':')[1]).to_i
+  end
+
   def self.transport
     # TODO: support Facter url to simplify testing. this will be removed in the final release.
     url= Facter.url ? Facter.url : 'https://admin:admin@f5.puppetlabs.lan/'

--- a/lib/puppet/provider/f5_node/f5_node.rb
+++ b/lib/puppet/provider/f5_node/f5_node.rb
@@ -44,11 +44,11 @@ Puppet::Type.type(:f5_node).provide(:f5_node, :parent => Puppet::Provider::F5) d
 
   def connection_limit
     val = transport[wsdl].get_connection_limit(resource[:name]).first
-    [val.high, val.low]
+    to_64s(val)
   end
 
   def connection_limit=(value)
-    transport[wsdl].set_connection_limit(resource[:name], resource[:connection_limit])
+    transport[wsdl].set_connection_limit(resource[:name], [ to_32h(resource[:connection_limit]) ])
   end
 
   def monitor_association

--- a/lib/puppet/provider/f5_snattranslationaddress/f5_snattranslationaddress.rb
+++ b/lib/puppet/provider/f5_snattranslationaddress/f5_snattranslationaddress.rb
@@ -45,11 +45,11 @@ Puppet::Type.type(:f5_snattranslationaddress).provide(:f5_snattranslationaddress
 
   def connection_limit
     val = transport[wsdl].get_connection_limit(resource[:name]).first
-    [val.high, val.low]
+    to_64s(val)
   end
 
   def connection_limit=(value)
-    val = transport[wsdl].set_connection_limit(resource[:name], resource[:connection_limit])
+    val = transport[wsdl].set_connection_limit(resource[:name], [ to_32h(resource[:connection_limit]) ])
   end
 
   def create

--- a/lib/puppet/type/f5_virtualserver.rb
+++ b/lib/puppet/type/f5_virtualserver.rb
@@ -27,22 +27,22 @@ Puppet::Type.newtype(:f5_virtualserver) do
   end
 
   newproperty(:cmp_enable_mode) do
-    desc "The virtula server cmp enable mode."
+    desc "The virtual server cmp enable mode."
     newvalues(/^RESOURCE_TYPE_CMP_ENABLE_(ALL|SINGLE|GROUP|UNKNOWN)$/)
   end
 
   newproperty(:cmp_enabled_state) do
-    desc "The virtula server cmp enable state."
+    desc "The virtual server cmp enable state."
     newvalues(/^STATE_(DISABLED|ENABLED)$/)
   end
 
   newproperty(:connection_limit) do
-    desc "The virtula server connection limit."
+    desc "The virtual server connection limit."
     newvalues(/^\d+$/)
   end
 
   newproperty(:connection_mirror_state) do
-    desc "The virtula server connection limit."
+    desc "The virtual server connection limit."
     newvalues(/^STATE_(DISABLED|ENABLED)$/)
   end
 
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:f5_virtualserver) do
   end
 
   newproperty(:destination) do
-    desc "The virtual server destination virtual addrss adn port."
+    desc "The virtual server destination virtual address and port."
   end
 
   newproperty(:enabled_state) do


### PR DESCRIPTION
Add support for F5 representation of 64bit as {:high => 32int, :low =>
32int}. Since it doesn't make sense to force user to manually bit shift.
The provider will convert the number as necessary when retrieving and
changing attributes values. So now instead of:
connection_limit => [11, 2712..],
now simply specify:
connection_limit => '500000',
