### PR TITLE
Implement F5 key/certificate provider.

### DIFF
--- a/lib/puppet/provider/f5_certificate/f5_certificate.rb
+++ b/lib/puppet/provider/f5_certificate/f5_certificate.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+require 'digest/md5'
 require 'puppet/provider/f5'
 
 Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::Provider::F5 ) do
@@ -5,6 +7,8 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
 
   confine :feature => :posix
   defaultfor :feature => :posix
+
+  @f5certs
 
   def self.wsdl
     'Management.KeyCertificate'
@@ -14,29 +18,14 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
     self.class.wsdl
   end
 
-  @f5certs
-
   def self.instances
-    modes = [ "MANAGEMENT_MODE_DEFAULT",
-              "MANAGEMENT_MODE_WEBSERVER",
-              "MANAGEMENT_MODE_EM",
-              "MANAGEMENT_MODE_IQUERY",
-              "MANAGEMENT_MODE_IQUERY_BIG3D" ]
-
-    certs = []
-    self.cache
-    require 'pp'
-    pp @f5certs
-    modes.each do |mode|
-      begin
-      certs += transport[wsdl].get_certificate_list(mode).collect do |cert|
-        new(:name => cert.certificate.cert_info.id, :is_bundled => cert.is_bundled, :file_name => cert.file_name, :mode => mode)
-      end
-      rescue Exception => e
-        Puppet.debug("Puppet::Provider::F5_Certificate: ignoring get_certificate_list exception \n #{e.message}")
-      end
+    unless @f5certs
+      self.cache
     end
-    certs
+
+    @f5certs.collect{ |name, value|
+      new(:name => name)
+    }
   end
 
   def self.cache
@@ -48,19 +37,16 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
               "MANAGEMENT_MODE_IQUERY",
               "MANAGEMENT_MODE_IQUERY_BIG3D" ]
 
-    certs = []
     modes.each do |mode|
       begin
-      transport[wsdl].get_certificate_list(mode).collect do |cert|
-        @f5certs[cert.certificate.cert_info.id] = cert
-                                                  # { :is_bundled => cert.is_bundled,
-                                                  #  :file_name => cert.file_name,
-                                                  #  :mode => mode }
-        #
-        require 'pp'
-        pp (cert.methods - SOAP::Mapping::Object.instance_methods).sort
-        pp cert.certificate
-      end
+        transport[wsdl].get_certificate_list(mode).each do |cert|
+          # F5 certificate bundles have a single cert id so we can't manage them individually, only as a single bundle.
+          cert_id = cert.certificate.cert_info.id
+            @f5certs[cert_id] = { :certificate => cert.certificate,
+                                  :file_name   => cert.file_name,
+                                  :is_bundled  => cert.is_bundled,
+                                  :mode        => mode }
+        end
       rescue Exception => e
         # We simply treat this as no certificates.
         # SOAP::FaultError: Exception caught in Management::urn:iControl:Management/KeyCertificate::get_certificate_list()
@@ -68,15 +54,68 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
         Puppet.debug("Puppet::Provider::F5_Certificate: ignoring get_certificate_list exception \n #{e.message}")
       end
     end
+    @f5certs
   end
 
+  def cache
+    self.class.cache
+  end
 
-  # TODO: need to implement caching for this.
-  def cert_info
+  def self.lookup(key)
+    unless @f5certs and @f5certs[key]
+      self.cache
+    end
+
+    @f5certs[key]
+  end
+
+  def lookup(key)
+    self.class.lookup(key)
+  end
+
+  # This is intended to decode certificate (subject, serial, issuer, expiration) for comparison.
+  def decode(content)
+    cert = case content.split("\n").first
+           when /BEGIN X509 CRL/
+             OpenSSL::X509::CRL
+           when /BEGIN CERTIFICATE REQUEST/
+             OpenSSL::X509::Request
+           when /BEGIN CERTIFICATE/
+             OpenSSL::X509::Certificate
+           when /BEGIN RSA (PRIVATE|PUBLIC) KEY/
+             OpenSSL::PKey::RSA
+           else return nil
+           end
+    cert.new(content)
+  rescue Exception => e
+    Puppet.debug("Puppet::Provider::F5_Cert: failed to decode certificate #{resource[:name]} content. Error: #{e.message}")
+  end
+
+  # Calculate cert fingerprint
+  def fingerprint(content)
+    cert = decode(content)
+    Digest::SHA1.hexdigest(cert.to_der)
+  end
+
+  def content
+    cert = transport[wsdl].certificate_export_to_pem(lookup(resource[:name])[:mode], resource[:name]).first
+    "sha1(#{fingerprint(cert)})"
+  end
+
+  def content=(value)
+    Puppet.debug("Puppet::Provider::F5_Cert: replacing cetificate #{resource[:name]}")
+    transport[wsdl].certificate_import_from_pem(resource[:mode], [resource[:name]], [ resource[:real_content] ], true)
+  end
+
+  def create
+    transport[wsdl].certificate_import_from_pem(resource[:mode], [resource[:name]], [ resource[:real_content] ], true)
+  end
+
+  def destroy
+    transport[wsdl].certificate_delete(resource[:mode], [ resource[:name] ])
   end
 
   def exists?
-    # transport[wsdl].get_list.include?(resource[:name])
-    true
+    lookup(resource[:name])
   end
 end

--- a/lib/puppet/provider/f5_key/f5_key.rb
+++ b/lib/puppet/provider/f5_key/f5_key.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
   confine :feature => :posix
   defaultfor :feature => :posix
 
-  @f5key
+  @f5keys
 
   def self.wsdl
     'Management.KeyCertificate'
@@ -17,17 +17,17 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
   end
 
   def self.instances
-    unless @f5key
+    unless @f5keys
       self.cache
     end
 
-    @f5key.collect{ |name, value|
+    @f5keys.collect{ |name, value|
       new(:name => name)
     }
   end
 
   def self.cache
-    @f5key ||= {}
+    @f5keys ||= {}
 
     modes = [ "MANAGEMENT_MODE_DEFAULT",
               "MANAGEMENT_MODE_WEBSERVER",
@@ -38,7 +38,7 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
     modes.each do |mode|
       begin
         transport[wsdl].get_key_list(mode).collect do |key|
-          @f5key[key.key_info.id] = { :info => key.key_info,
+          @f5keys[key.key_info.id] = { :info => key.key_info,
                                       :mode => mode }
         end
       rescue Exception => e
@@ -49,11 +49,11 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
       end
     end
 
-    @f5key
+    @f5keys
   end
 
   def self.cache_delete(key)
-    @f5key.delete(key)
+    @f5keys.delete(key)
   end
 
   def cache
@@ -65,11 +65,11 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
   end
 
   def self.lookup(key)
-    unless @f5key and @f5key[key]
+    unless @f5keys and @f5keys[key]
       self.cache
     end
 
-    @f5key[key]
+    @f5keys[key]
   end
 
   def lookup(key)

--- a/lib/puppet/type/f5_certificate.rb
+++ b/lib/puppet/type/f5_certificate.rb
@@ -1,3 +1,6 @@
+require 'openssl'
+require 'digest/md5'
+
 Puppet::Type.newtype(:f5_certificate) do
   @doc = "Manage F5 certificate."
 
@@ -21,16 +24,26 @@ Puppet::Type.newtype(:f5_certificate) do
     desc "The key name."
   end
 
-  #newparam(:file) do
-  #  desc "The cerficate file (content)."
-  #end
-  #
+  newparam(:real_content) do
+    desc "Store actual PEM file content."
+  end
+
+  newproperty(:content) do
+    desc "The cerficate file PEM content (fingerprint compared)."
+
+    munge do |value|
+      resource[:real_content] = value
+      Puppet.debug(value)
+      Puppet.debug("sha1(#{Digest::MD5.hexdigest(OpenSSL::X509::Certificate.new(value).to_der)}")
+      "sha1(#{Digest::SHA1.hexdigest(OpenSSL::X509::Certificate.new(value).to_der)}"
+    end
+  end
+
   newparam(:mode) do
     desc "The certificate management mode type."
 
-  end
+    defaultto("MANAGEMENT_MODE_DEFAULT")
 
-  #newproperty(:cert_info) do
-  #  desc "some demo."
-  #end
+    newvalues(/^MANAGEMENT_MODE_(DEFAULT|WEBSERVER|EM|IQUERY|IQUERY_BIG3D)$/)
+  end
 end


### PR DESCRIPTION
This will fetch and compare certificate sha1 fingerprint. After testing
several other methods this is the most reliable, despite the additional
overhead of retrieving PEM certs. This is also the easiest way to handle
ceritificate bundles.
