### PR TITLE
Adding prefetching to keys

### DIFF
--- a/lib/puppet/provider/f5_key/f5_key.rb
+++ b/lib/puppet/provider/f5_key/f5_key.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
   end
 
   def exists?
-    Puppet.debug("Puppet::Provider::F5_key::Ensure: #{@property_hash[:ensure]}")
+    Puppet.debug("Puppet::Provider::F5_key::Ensure for #{@property_hash[:name]}: #{@property_hash[:ensure]}")
     @property_hash[:ensure] != :absent
   end
 end


### PR DESCRIPTION
Adds prefetching to keys instead of the cache methods.

Rebased from earlier today to allow clean merging.
