### PR TITLE
Update f5 pool create to support all attributes.

### DIFF
--- a/lib/puppet/provider/f5_pool/f5_pool.rb
+++ b/lib/puppet/provider/f5_pool/f5_pool.rb
@@ -25,7 +25,6 @@ Puppet::Type.type(:f5_pool).provide(:f5_pool, :parent => Puppet::Provider::F5) d
     'allow_snat_state',
     'client_ip_tos',                      # Array
     'client_link_qos',                    # Array
-    'description',
     'gateway_failsafe_device',
     'gateway_failsafe_unit_id',           # Array
     'lb_method',
@@ -108,7 +107,29 @@ Puppet::Type.type(:f5_pool).provide(:f5_pool, :parent => Puppet::Provider::F5) d
 
   def create
     Puppet.debug("Puppet::Provider::F5_Pool: creating F5 pool #{resource[:name]}")
+    # [[]] because we will add members later using member=...
     transport[wsdl].create(resource[:name], resource[:lb_method], [[]])
+
+    methods = [ 'action_on_service_down',
+    'allow_nat_state',
+    'allow_snat_state',
+    'client_ip_tos',                      # Array
+    'client_link_qos',                    # Array
+    'gateway_failsafe_device',
+    'gateway_failsafe_unit_id',           # Array
+    'lb_method',
+    'minimum_active_member',              # Array
+    'minimum_up_member',                  # Array
+    'minimum_up_member_action',
+    'minimum_up_member_enabled_state',
+    'server_ip_tos',
+    'server_link_qos',
+    'simple_timeout',
+    'slow_ramp_time']
+    methods << "monitor_association" << "member"
+    methods.each do |method|
+      self.send("#{method}=", "a") if resource[method.to_sym]
+    end
   end
 
   def destroy

--- a/lib/puppet/type/f5_pool.rb
+++ b/lib/puppet/type/f5_pool.rb
@@ -47,11 +47,6 @@ Puppet::Type.newtype(:f5_pool) do
     newvalues(/^\d+$/)
   end
 
-  newproperty(:description) do
-    desc "The pool description."
-    # Only available in 11.0
-  end
-
   newproperty(:gateway_failsafe_device) do
     desc "The pool gateway failsafe device."
   end
@@ -68,9 +63,6 @@ Puppet::Type.newtype(:f5_pool) do
 
   newproperty(:member, :parent => Puppet::Property::List) do
     desc "The pool member."
-    #munge do |value|
-    #  Array(value)
-    #end
   end
 
   newparam(:membership) do


### PR DESCRIPTION
Previously f5_pool create wasn't setting all resource attributes. Now
it's setting all attributes during creation.
