### PR TITLE
Minor fixes to keep @property_hash from being blank

### DIFF
--- a/lib/puppet/provider/f5_certificate/f5_certificate.rb
+++ b/lib/puppet/provider/f5_certificate/f5_certificate.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
           # them individually, only as a single bundle.
           cert = {
             :name   => cert.certificate.cert_info.id,
-            :ensure => 'present',
+            :ensure => :present,
             :mode   => mode
           }
           f5certs << new(cert)
@@ -90,6 +90,6 @@ Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::P
 
   def exists?
     Puppet.debug("Puppet::Provider::F5_certificate::Ensure for #{@property_hash[:name]}: #{@property_hash[:ensure]}")
-    @property_hash[:ensure] != :absent
+    @property_hash[:ensure] == :present
   end
 end

--- a/lib/puppet/provider/f5_key/f5_key.rb
+++ b/lib/puppet/provider/f5_key/f5_key.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
         transport[wsdl].get_key_list(mode).collect do |key|
           key = {
             :name   => key.key_info.id,
-            :ensure => 'present',
+            :ensure => :present,
             :mode   => mode
           }
           f5keys << new(key)
@@ -85,6 +85,6 @@ Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
 
   def exists?
     Puppet.debug("Puppet::Provider::F5_key::Ensure for #{@property_hash[:name]}: #{@property_hash[:ensure]}")
-    @property_hash[:ensure] != :absent
+    @property_hash[:ensure] == :present
   end
 end


### PR DESCRIPTION
I looked through many core puppet providers that prefetch resources and I
couldn't figure out why @property_hash was always blank.  I talked with nan
briefly and we couldn't figure out what was happening in our environment.  This
is the patch that made things start working for me.
