### PR TITLE
Update F5 pool monitor_association to use hashes.

### DIFF
--- a/lib/puppet/provider/f5_pool/f5_pool.rb
+++ b/lib/puppet/provider/f5_pool/f5_pool.rb
@@ -87,22 +87,18 @@ Puppet::Type.type(:f5_pool).provide(:f5_pool, :parent => Puppet::Provider::F5) d
   def monitor_association
     monitor = transport[wsdl].get_monitor_association(resource[:name]).first.monitor_rule
 
-    # Puppet still flattens this to [ , , ] instead of nesting the array.
-    [ monitor.type, monitor.quorum.to_s, *monitor.monitor_templates ]
+    { 'type' => monitor.type, 'quorum' => monitor.quorum.to_s, 'monitor_templates' => monitor.monitor_templates }
   end
 
   def monitor_association=(value)
     monitor = resource[:monitor_association]
-    newval = [
-      :pool_name    => resource[:name],
-      :monitor_rule => {
-        :type              => monitor.shift,
-        :quorum            => monitor.shift,
-        :monitor_templates => monitor,
-      }
-    ]
+    newval = { :pool_name    => resource[:name],
+               :monitor_rule => { :type              => monitor['type'],
+                                  :quorum            => monitor['quorum'],
+                                  :monitor_templates => monitor['monitor_templates'] }
+             }
 
-    transport[wsdl].set_monitor_association(newval)
+    transport[wsdl].set_monitor_association([newval])
   end
 
   def create

--- a/lib/puppet/type/f5_pool.rb
+++ b/lib/puppet/type/f5_pool.rb
@@ -87,8 +87,16 @@ Puppet::Type.newtype(:f5_pool) do
     desc "The pool minimum up member enabed state."
   end
 
-  newproperty(:monitor_association, :array_matching => :all) do
+  newproperty(:monitor_association) do
     desc "The pool monitor association."
+
+    def should_to_s(newvalue)
+      newvalue.inspect
+    end
+
+    def is_to_s(currentvalue)
+      currentvalue.inspect
+    end
   end
 
   newproperty(:server_ip_tos) do


### PR DESCRIPTION
The update replace monitor_association with a hash. This also improves
the output when changes occur:

notice: /Stage[main]//F5_pool[webserver3]/monitor_association:
monitor_association changed '{"type"=>"MONITOR_RULE_TYPE_AND_LIST",
"monitor_templates"=>["http"], "quorum"=>"0"}' to
'{"type"=>"MONITOR_RULE_TYPE_AND_LIST", "quorum"=>"0",
"monitor_templates"=>["http", "demo2", "demo3"]}'
