### PR TITLE
(#11069) Fix F5 monitor integer property.

### DIFF
--- a/lib/puppet/provider/f5_monitor/f5_monitor.rb
+++ b/lib/puppet/provider/f5_monitor/f5_monitor.rb
@@ -121,9 +121,8 @@ Puppet::Type.type(:f5_monitor).provide(:f5_monitor, :parent => Puppet::Provider:
   def template_integer_property=(value)
     resource[:template_integer_property].each do |k, v|
       # Trying to configure ITYPE_UNSET results in Exception: Common::OperationFailed
-      transport[wsdl].set_template_integer_property(resource[:name], [{:type => k, :value => v}]) unless k = 'ITYPE_UNSET'
+      transport[wsdl].set_template_integer_property(resource[:name], [{:type => k, :value => v}]) unless k == 'ITYPE_UNSET'
     end
-    true
   end
 
   def template_string_property


### PR DESCRIPTION
F5 monitor wasn't updating integer property after initial creation. This
fixes the problem.
