### PR TITLE
(#11575) Fix broken spec tests.

### DIFF
--- a/spec/unit/puppet/type/f5_node_spec.rb
+++ b/spec/unit/puppet/type/f5_node_spec.rb
@@ -17,7 +17,7 @@ describe res_type do
     type
   }
   let(:resource) {
-    res_type.new({:name => 'test_node'})
+    res_type.new({:name => 'test.node'})
   }
 
   it 'should have :name be its namevar' do
@@ -28,7 +28,7 @@ describe res_type do
   # for people not familiar with rspec.
   parameter_tests = {
     :name => {
-      :valid => ["test_node", "test node"],
+      :valid => ["test.node", "testnode"],
       :default => "test", # just to make tests pass
     },
     :connection_limit => {


### PR DESCRIPTION
The original commit was intended to be strictly documentation changes to
match F5 icontrol documentation.  The update included changes to f5_node
namevar validation which broke spec tests.  This patch fixes the problem
since f5_node name should either be ipaddress or hostnames.
