### PR TITLE
(#12187) F5_Monitor provider : Fix set_template_destination arguments

### DIFF
--- a/lib/puppet/provider/f5_monitor/f5_monitor.rb
+++ b/lib/puppet/provider/f5_monitor/f5_monitor.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:f5_monitor).provide(:f5_monitor, :parent => Puppet::Provider:
   end
 
   def template_destination=(value)
-    transport[wsdl].set_template_destination(monitor_ipport(resource[:template_destination]))
+    transport[wsdl].set_template_destination([resource[:name]], [monitor_ipport(resource[:template_destination])])
   end
 
   def template_integer_property


### PR DESCRIPTION
The current method only pass destination.

http://devcentral.f5.com/wiki/iControl.LocalLB__Monitor__set_template_destination.ashx

void set_template_destination(
    in String[] template_names,
    in MonitorIPPort[] destinations
)
