### PR TITLE
(#12135) Fix profileclientssl initialization.

### DIFF
--- a/lib/puppet/provider/f5.rb
+++ b/lib/puppet/provider/f5.rb
@@ -32,8 +32,9 @@ class Puppet::Provider::F5 < Puppet::Provider
       @device ||= Puppet::Util::NetworkDevice::F5::Device.new(Facter.value(:url))
     else
       @device ||= Puppet::Util::NetworkDevice.current
-      raise Puppet::Error, "Puppet::Util::NetworkDevice::F5: device not initialized." unless @device
+      raise Puppet::Error, "Puppet::Util::NetworkDevice::F5: device not initialized #{caller.join("\n")}" unless @device
     end
+
     @tranport = @device.transport
   end
 

--- a/lib/puppet/provider/f5_certificate/f5_certificate.rb
+++ b/lib/puppet/provider/f5_certificate/f5_certificate.rb
@@ -1,5 +1,4 @@
 require 'puppet/provider/f5'
-require 'puppet/util/network_device/f5'
 
 Puppet::Type.type(:f5_certificate).provide(:f5_certificate, :parent => Puppet::Provider::F5 ) do
   @doc = "Manages f5 certificates"

--- a/lib/puppet/provider/f5_key/f5_key.rb
+++ b/lib/puppet/provider/f5_key/f5_key.rb
@@ -1,5 +1,4 @@
 require 'puppet/provider/f5'
-require 'puppet/util/network_device/f5'
 
 Puppet::Type.type(:f5_key).provide(:f5_key, :parent => Puppet::Provider::F5) do
   @doc = "Manages f5 cert"

--- a/lib/puppet/type/f5_certificate.rb
+++ b/lib/puppet/type/f5_certificate.rb
@@ -1,5 +1,3 @@
-require 'puppet/util/network_device/f5'
-
 Puppet::Type.newtype(:f5_certificate) do
   @doc = "Manage F5 certificate."
 

--- a/lib/puppet/type/f5_key.rb
+++ b/lib/puppet/type/f5_key.rb
@@ -1,5 +1,3 @@
-require 'puppet/util/network_device/f5'
-
 Puppet::Type.newtype(:f5_key) do
   @doc = "Manage F5 key."
 


### PR DESCRIPTION
Originally the implimentation alias an f5 icontrol internal API. This
causes an issue on compilation on the puppet master because it attempts
to initialize f5 device when it has no connectivity information.
