### PR TITLE
(#11617) F5_external_class supports refresh.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,7 @@ The following puppet manifest will deploy f5 gem on the f5_proxy system and depl
 
         export RUBYLIB=/etc/puppet/modules/f5/lib/:$RUBYLIB
 
-For more information see: http://www.puppetlabs.com/blog/puppet-network-device-management/
+For more information see our website on [network device management](http://www.puppetlabs.com/blog/puppet-network-device-management/).
 
 ## F5 Facts
 Similar to Puppet 2.7 cisco devices, the F5 facts are not collected via facter, so please review $vardir/yaml/facts for F5 system information.
@@ -131,8 +131,7 @@ Similar to Puppet 2.7 cisco devices, the F5 facts are not collected via facter, 
         !ruby/sym version: BIG-IP_v10.1.0
 
 ## Appendix
-Sample Puppet F5 manifests and usage notes where applicable. F5 API documentation:
-http://devcentral.f5.com/wiki/iControl.APIReference.ashx
+Sample Puppet F5 manifests and usage notes where applicable. See [F5 iControl API documentation](http://devcentral.f5.com/wiki/iControl.APIReference.ashx) for more more information.
 
 f5_(key|certificate) content attribute accepts the certificate in PEM format:
 
@@ -159,7 +158,7 @@ Certificates comparison is completed via sha1 fingerprint which is also used dur
 
     notice: /Stage[main]//F5_certificate[ca-bundle]/content: content changed 'sha1(0197e53f31798d43eac830b8561887dae22fd5c2)' to 'sha1(39c2e7fa576e98431bbab66ca0cb14e01cb8bfe4)'
 
-f5_file resource is intended for f5_external_class to manage datagroup files. The performance in v10 is slow because it requires downloading the file to calculate the file checksum. Content should be the string content of the file, and internally the type converts into md5 checksum (example below content comparison value is 'md5(b8353824beaf868010d823cf128ecc97)'). f5_files are processed in 64KB chunks per F5 recommendation: http://devcentral.f5.com/Tutorials/TechTips/tabid/63/articleType/ArticleView/articleId/144/iControl-101--06--File-Transfer-APIs.aspx.
+f5_file resource is intended for f5_external_class to manage datagroup files. The performance in v10 is slow because it requires downloading the file to calculate the file checksum. Content should be the string content of the file, and internally the type converts into md5 checksum (example below content comparison value is 'md5(b8353824beaf868010d823cf128ecc97)'). f5_files are processed in 64KB chunks per F5 [techtips recommendation](http://devcentral.f5.com/Tutorials/TechTips/tabid/63/articleType/ArticleView/articleId/144/iControl-101--06--File-Transfer-APIs.aspx).
 
     f5_file { '/config/addr.class':
       ensure  => 'present',
@@ -209,7 +208,7 @@ F5_pool resource notes:
 * The member attribute is not order dependent, the monitor_associate is order dependent.
 * The member attribute may contain addresses A.B.C.D%ID such as: 192.168.1.1.%0, ID indicates route domain (0 is common).
 
-See F5 documentation: http://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_1/tmos_route_domains.html
+See [F5 documentation](http://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos_management_guide_10_1/tmos_route_domains.html) for more information.
 
     f5_pool { 'webserver':
       ensure                          => 'present',
@@ -272,7 +271,7 @@ See F5 documentation: http://support.f5.com/kb/en-us/products/big-ip_ltm/manuals
       unit_id          => '1',
     }
 
-F5_virtualserver does not atomically change rules (F5 API limitation), so to reorder rule priority please use irule priority which can be modified in f5_rule. See: http://devcentral.f5.com/wiki/iRules.priority.ashx
+F5_virtualserver does not atomically change rules (F5 API limitation), so to reorder rule priority please use irule priority which can be modified in f5_rule. See [F5 documentation](http://devcentral.f5.com/wiki/iRules.priority.ashx).
 
     f5_virtualserver { 'www':
       ensure                  => 'present',
@@ -305,6 +304,8 @@ F5 datagroup consists of f5_string_class and f5_external_class. f5_external_clas
       members => {'en' => '', 'ja' => '', 'zh-cn' => '', 'zh-tw' => ''},
     }
 
+f5_external_class resource using external data group should subscribe to f5_file to trigger a data reload when the file content changes.  This issue is explained in further details in the following [F5 techtip](http://devcentral.f5.com/Tutorials/TechTips/tabid/63/articleType/ArticleView/articleId/33/Forcing-a-reload-of-External-Data-Groups-within-an-iRule.aspx).
+
     f5_external_class { 'addr':
       ensure         => 'present',
       data_separator => ':=',
@@ -312,6 +313,7 @@ F5 datagroup consists of f5_string_class and f5_external_class. f5_external_clas
       file_mode      => 'FILE_MODE_TYPE_READ_WRITE',
       file_name      => '/config/addr.class',
       type           => 'CLASS_TYPE_ADDRESS',
+      subscribe      => F5_file['/config/addr.class'],
     }
 
 ## Development

--- a/lib/puppet/provider/f5_external_class/f5_external_class.rb
+++ b/lib/puppet/provider/f5_external_class/f5_external_class.rb
@@ -1,7 +1,7 @@
 require 'puppet/provider/f5'
 
 Puppet::Type.type(:f5_external_class).provide(:f5_external_class, :parent => Puppet::Provider::F5) do
-  @doc = "Manages f5 String classes (datagroups)"
+  @doc = "Manages f5 external classes (datagroups)"
 
   confine :feature => :posix
   defaultfor :feature => :posix
@@ -62,7 +62,7 @@ Puppet::Type.type(:f5_external_class).provide(:f5_external_class, :parent => Pup
     # F5 external class can not conflict with address, string, or value class
     # namevar.  Since Puppet can not enforce unique resource names, it is not
     # safe to delete the class.
-    Puppet.debug("Puppet::Provider::F5_external_class: creating F5 string class #{resource[:name]}")
+    Puppet.debug("Puppet::Provider::F5_external_class: creating F5 external class #{resource[:name]}")
 
     metainfo = {
                  :class_name  => resource[:name],
@@ -76,9 +76,14 @@ Puppet::Type.type(:f5_external_class).provide(:f5_external_class, :parent => Pup
   end
 
   def destroy
-    Puppet.debug("Puppet::Provider::F5_external_class: deleting F5 string class #{resource[:name]}")
+    Puppet.debug("Puppet::Provider::F5_external_class: deleting F5 external class #{resource[:name]}")
 
     transport[wsdl].delete_class(resource[:name])
+  end
+
+  def refresh
+    Puppet.debug("Puppet::Provider::F5_external_class: refreshing F5 external class #{resource[:name]}")
+    transport[wsdl].set_external_class_file_name(resource[:name], resource[:file_name])
   end
 
   def exists?

--- a/lib/puppet/type/f5_external_class.rb
+++ b/lib/puppet/type/f5_external_class.rb
@@ -3,8 +3,18 @@ Puppet::Type.newtype(:f5_external_class) do
 
   apply_to_device
 
+  # Refreshable feature used to force reload of external data group.  The issue
+  # is explained below but we use a different work around:
+  # http://devcentral.f5.com/Tutorials/TechTips/tabid/63/articleType/ArticleView/articleId/33/Forcing-a-reload-of-External-Data-Groups-within-an-iRule.aspx
+  feature :refreshable, "The provider can refresh",
+    :methods => [:refresh]
+
   ensurable do
-    desc "F5 External Class resource state. Valid values are present, absent."
+    desc "F5 External Class resource state. Valid values are present, absent.
+
+    f5_external_class supports refresh for external data groups as a work around for this limitation:
+    http://devcentral.f5.com/Tutorials/TechTips/tabid/63/articleType/ArticleView/articleId/33/Forcing-a-reload-of-External-Data-Groups-within-an-iRule.aspx
+    "
 
     defaultto(:present)
 
@@ -64,5 +74,10 @@ Puppet::Type.newtype(:f5_external_class) do
     if f5_file = self[:file_name]
       f5_file
     end
+  end
+
+  def refresh
+    # Refresh only makes sense for external data groups that have files.
+    provider.refresh unless self[:file_name].nil?
   end
 end


### PR DESCRIPTION
F5_external_class doesn't detect and reload when the data group files
change. The resource have been updated to support the ability to reload
when f5_file resource changes.
