### PR TITLE
Add chain_file support for f5_profileclientssl

### DIFF
--- a/lib/puppet/provider/f5_profileclientssl/f5_profileclientssl.rb
+++ b/lib/puppet/provider/f5_profileclientssl/f5_profileclientssl.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:f5_profileclientssl).provide(:f5_profileclientssl, :parent =>
     'ca_file',
     'client_certificate_ca_file',
     'peer_certification_mode',
+    'chain_file',
   ]
 
   methods.each do |method|
@@ -42,6 +43,7 @@ Puppet::Type.type(:f5_profileclientssl).provide(:f5_profileclientssl, :parent =>
     'key_file',
     'ca_file',
     'client_certificate_ca_file',
+    'chain_file',
   ]
 
   methods.each do |method|
@@ -79,6 +81,10 @@ Puppet::Type.type(:f5_profileclientssl).provide(:f5_profileclientssl, :parent =>
 
     if resource[:peer_certification_mode]
       self.peer_certification_mode = resource[:peer_certification_mode]
+    end
+
+    if resource[:chain_file]
+      self.chain_file = resource[:chain_file]
     end
   end
 

--- a/lib/puppet/type/f5_profileclientssl.rb
+++ b/lib/puppet/type/f5_profileclientssl.rb
@@ -43,4 +43,8 @@ Puppet::Type.newtype(:f5_profileclientssl) do
   newproperty(:peer_certification_mode) do
     desc "The peer certification modes for the specified client SSL profiles."
   end
+
+  newproperty(:chain_file) do
+    desc "The certificate chain filenames for the specified client SSL profiles."
+  end
 end


### PR DESCRIPTION
Adding support for chain_file to f5_profileclientssl.  This will allow users to supply intermediate certificates.
