### PR TITLE
Update f5_virtualserver.rb

### DIFF
--- a/lib/puppet/provider/f5_virtualserver/f5_virtualserver.rb
+++ b/lib/puppet/provider/f5_virtualserver/f5_virtualserver.rb
@@ -272,6 +272,11 @@ Puppet::Type.type(:f5_virtualserver).provide(:f5_virtualserver, :parent => Puppe
     vs_wildmask  = resource[:wildmask]
     vs_resources = { :type => resource[:type] }
     vs_profiles  = []
+    
+    resource[:profile].each do |k, v|
+      vs_profiles << { :profile_name    => k,
+                       :profile_context => v }
+    end
 
     transport[wsdl].create([vs_definition], vs_wildmask, [vs_resources], [vs_profiles])
 


### PR DESCRIPTION
Add profiles to virtual server during creation in order to use tcp profiles other than the default. The default tcp profile cannot be changed atomically after the virtual server has been created.
