### PR TITLE
Fix uninitialized constant error in Puppet 3

### DIFF
--- a/lib/puppet/util/network_device/f5.rb
+++ b/lib/puppet/util/network_device/f5.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 require 'digest/sha1'
-
+require 'puppet/util/network_device'
 module Puppet::Util::NetworkDevice::F5
   # This is intended to decode certificate (subject, serial, issuer, expiration) for comparison.
   def self.decode(content)


### PR DESCRIPTION
Prior to this commit identically configured Puppet Masters running
`ruby 1.8.7 (2011-06-30 patchlevel 352) [x86_64-linux]` and puppet
`3.3.2` and `2.7.23` would fail to compile the catalog for identical
manifests that included any declarations for these types.

This commit fixes an uninitialized constant Puppet::Util::NetworkDevice
error.

Example of this are:
1. example1.customer.com
   Could not autoload puppet/type/f5_rule: Could not autoload puppet/provider/f5_rule/f5_rule: uninitialized constant Puppet::Util::NetworkDevice on node...
2. example2.customer.com
   Could not autoload puppet/type/f5_profilepersistence: Could not autoload puppet/provider/f5_profilepersistence/f5_profilepersistence: uninitialized constant Puppet::Util::NetworkDevice on node...
3. example3.customer.com
   Could not autoload puppet/type/f5_virtualserver: Could not autoload puppet/provider/f5_virtualserver/f5_virtualserver: uninitialized constant Puppet::Util::NetworkDevice on node...
4. example3.customer.com
   Could not autoload puppet/type/f5_pool: Could not autoload puppet/provider/f5_pool/f5_pool: uninitialized constant Puppet::Util::NetworkDevice on...
5. example5-dist-stage.customer.com
   Could not autoload puppet/type/f5_file: Could not autoload puppet/provider/f5_file/f5_file: uninitialized constant Puppet::Util::NetworkDevice on node...
