### PR TITLE
Fix to_a since it is no longer in Ruby 2+

### DIFF
--- a/lib/puppet/type/f5_pool.rb
+++ b/lib/puppet/type/f5_pool.rb
@@ -115,7 +115,7 @@ Puppet::Type.newtype(:f5_pool) do
     munge do |value|
       # Make sure monitor_templates is converted to an array to aid with
       # matching
-      value["monitor_templates"] = value["monitor_templates"].to_a
+      value["monitor_templates"] = Array(value["monitor_templates"])
       value
     end
 

--- a/lib/puppet/type/f5_snat.rb
+++ b/lib/puppet/type/f5_snat.rb
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:f5_snat) do
           raise Puppet::Error, "Puppet::Type::F5_Snat: does not support vlan key #{k}" unless k =~ /^(state|vlans)$/
 
           # ensure vlan value is an array
-          value[k] = value[k].to_a if k == 'vlan'
+          value[k] = Array(value[k]) if k == 'vlan'
         end
 
         raise Puppet::Error, "Puppet::Type::F5_Snat: vlan missing key." unless value.size == 2

--- a/lib/puppet/type/f5_virtualserver.rb
+++ b/lib/puppet/type/f5_virtualserver.rb
@@ -153,7 +153,7 @@ Puppet::Type.newtype(:f5_virtualserver) do
           raise Puppet::Error, "Puppet::Type::F5_VirtualServer: vlan does not support key #{k}" unless k =~ /^(state|vlans)$/
 
           # ensure vlans value is an array
-          value[k] = value[k].to_a if k == 'vlans'
+          value[k] = Array(value[k]) if k == 'vlans'
         end
 
         raise Puppet::Error, "Puppet::Type::F5_VirtualServer: vlan missing key." unless value.size == 2


### PR DESCRIPTION
We're using Ruby 2.0 and `to_a` no longer works. Use `Array('string')` instead.
