### PR TITLE
Replace 'smart' quote with regular quote

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppetlabs-f5",
   "version": "0.6.2",
   "author": "Puppet Labs",
-  "summary": “Uses SOAP to manage F5 devices running 11.0+. Includes nineteen resources covering everything from users to irules.",
+  "summary": "Uses SOAP to manage F5 devices running 11.0+. Includes nineteen resources covering everything from users to irules.",
   "license": "Apache 2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-f5.git",
   "project_page": "http://github.com/puppetlabs/puppetlabs-f5",


### PR DESCRIPTION
metadata.json was invalid, used “ instead of " on the summary value.
